### PR TITLE
download and extract external deps in bld.bat

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,27 @@ REM brand Python with conda-forge startup message
 python %RECIPE_DIR%\brand_python.py
 if errorlevel 1 exit 1
 
+REM Download and unpack external dependencies
+mkdir externals
+cd externals
+
+for %%x in (xz-5.2.2 tk-8.6.6.0 tix-8.4.3.6 tcl-core-8.6.6.0 sqlite-3.14.2.0 openssl-1.0.2k bzip2-1.0.6) do (
+    curl -SLO https://github.com/python/cpython-source-deps/archive/%%x.zip
+    if errorlevel 1 exit 1
+    7za x -y %%x.zip
+    if errorlevel 1 exit 1
+    move cpython-source-deps-%%x %%x
+    if errorlevel 1 exit 1
+)
+
+curl -SLO https://github.com/python/cpython-bin-deps/archive/nasm-2.11.06.zip
+if errorlevel 1 exit 1
+7za x -y nasm-2.11.06.zip
+if errorlevel 1 exit 1
+move cpython-bin-deps-nasm-2.11.06 nasm-2.11.06
+if errorlevel 1 exit 1
+
+cd ..
 
 REM Compile python, extensions and external libraries
 if "%ARCH%"=="64" (

--- a/recipe/do-not-download-externals.patch
+++ b/recipe/do-not-download-externals.patch
@@ -1,0 +1,28 @@
+From 3881a792bbe66765ccf527853c96da0f84ba94b2 Mon Sep 17 00:00:00 2001
+From: Jonathan Helmus <jjhelmus@gmail.com>
+Date: Sun, 23 Jul 2017 16:20:49 -0500
+Subject: [PATCH] do not download externals
+
+Do not download externals in build.bat script.  Downloading and
+unpacking on external dependencies is done in the conda build bld.bat
+script.
+---
+ PCbuild/build.bat | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/PCbuild/build.bat b/PCbuild/build.bat
+index 8e1c168..2d602e1 100644
+--- a/PCbuild/build.bat
++++ b/PCbuild/build.bat
+@@ -88,7 +88,7 @@ if "%IncludeExternals%"=="" set IncludeExternals=false
+ if "%IncludeSSL%"=="" set IncludeSSL=true
+ if "%IncludeTkinter%"=="" set IncludeTkinter=true
+ 
+-if "%IncludeExternals%"=="true" call "%dir%get_externals.bat"
++rem if "%IncludeExternals%"=="true" call "%dir%get_externals.bat"
+ 
+ if "%platf%"=="x64" (
+     if "%on_64_bit%"=="true" (
+-- 
+2.13.3.windows.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ source:
     - mingw-w64--DMS_WINXX.patch
     - win-msc_ver-1900.patch
     - fix-ABI-issue29943.patch
+    - do-not-download-externals.patch  # [win]
 
 build:
   number: 0
@@ -37,7 +38,9 @@ build:
 
 requirements:
   build:
+    - 7za               # [win]
     - bzip2 1.0.*       # [unix]
+    - curl              # [win]
     - openssl 1.0.*     # [unix]
     - readline 6.2*     # [unix]
     - sqlite 3.13.*     # [unix]


### PR DESCRIPTION
Download and unpack external windows dependencies in bld.bat script
rather than depending on the logic in build.bat to perform this
function.